### PR TITLE
Updated to 12.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [maplibre]
+open_collective: maplibre

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Report a bug
+
+---
+
+<!--
+Hello! Thanks for contributing.  For the fastest response and resolution, please:
+
+ - Make the issue title a succinct but specific description of the unexpected behavior.
+   Bad: "Map zoom is broken". 
+   Good: "camera.setZoom(...) throws an exception for zoom levels where no tiles exist"
+
+ - Ensure that you have tested on a physical device, not just a simulator.
+
+ - For build issues: Can you reproduce it on a clean install of the example app? Please include full steps to reproduce
+
+ - Include a link to a minimal demonstration of the bug, ideally a single component with one MapView.
+
+ - Ensure you can reproduce the bug using the latest release.
+
+ - Only use this template for bug reports. Use the feature request template for requests, and direct general questions to Slack: https://slack.openstreetmap.us/.
+-->
+
+
+### Steps to Trigger Behavior
+
+1.
+2.
+3.
+
+### Link to Minimal Reproducible Example
+
+### Expected Behavior
+
+### Actual Behavior
+
+### Screenshots (if applicable)
+
+### Version(s) affected
+
+- Platform: [e.g. Android, iOS]
+- OS version: [e.g. Android 9, iOS 10]
+- Device type: [e.g. iPhone6]
+- Emulator/ Simulator: [yes/ no]
+- Development OS: [e.g. OSX 11.0.1, Win10]
+- maplibre-navigation-ios Version [e.g. 7.0.9]
+- MapLibre GL version [e.g. 6.3.0]
+
+### Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,53 @@
+---
+name: Feature request
+about: Suggest a feature or enhancement
+
+---
+
+## Motivation
+
+<!--
+What problem are we trying to solve?  Please link any relevant issues.
+What use cases are we trying to accommodate?
+
+Focus on the problem and save design ideas for the next section.
+-->
+
+## Design Alternatives
+
+<!--
+How could we accommodate the use cases above?
+Is "do nothing" an option?
+-->
+
+## Design
+
+<!--
+Which design should we implement?
+What are the advantages of this design?
+What are some potential drawbacks of this design?
+-->
+
+### Mock-Up
+
+<!--
+What will this design look like to developers?
+What will this design look like to end users?
+-->
+
+### Concepts
+
+<!--
+How will we teach this design?
+What terminology will work best for the new concepts introduced by this design?
+What existing precedents support the new concepts?
+Where do the concepts set new precedents?
+-->
+
+### Implementation
+
+<!--
+How you would implement the design?
+What parts of the MapLibre GL ecosystem (ex: underlying renderers) will need to change to accommodate this design?
+Are there any important edge cases?
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+# Contributor Covenant
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/maplibre/maplibre/blob/main/CODE_OF_CONDUCT.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Maplibre Directions for Swift
+
+## Reporting an issue
+
+Bug reports and feature requests are more than welcome, but please consider the following tips so we can respond to your feedback more effectively.
+
+Before reporting a bug here, please determine whether the issue lies with the MaplibreDirections package or with another Maplibre/Mapbox  product:
+
+When reporting a bug in the client-side MaplibreDirections package, please indicate:
+
+* The version of MaplibreDirections you installed
+* The version of Carthage that you used to install the package
+* The version of Xcode you used to build the package
+* The operating system version and device model on which you experienced the issue
+
+## Adding tests
+
+### Adding a test case
+
+1. Add a `test*` method to one of the classes in one of the files in [Tests/MapboxDirectionsTests/](./Tests/MapboxDirectionsTests/).
+
+## Opening a pull request
+
+Pull requests are appreciated. If your PR includes any changes that would impact developers or end users, please mention those changes in the “main” section of [CHANGELOG.md](CHANGELOG.md), noting the PR number. Examples of noteworthy changes include new features, fixes for user-visible bugs, and renamed or deleted public symbols.
+
+Before we can merge your PR, it must pass automated continuous integration checks on each of the supported platforms, as well as a check to ensure that code coverage has not decreased significantly.
+
+## Setup for creating pull requests
+
+* Fork this project
+* In your fork, create a branch, for example: fix/camera-update
+* Add your changes
+* Push and open a PR with your branch

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "raphaelmor/Polyline" ~> 4.2
+github "raphaelmor/Polyline" == 5.1.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,0 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.4
-github "AliSoftware/OHHTTPStubs" ~> 6.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.1.0
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.4
 github "AliSoftware/OHHTTPStubs" ~> 6.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,2 @@
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.1.0
+github "AliSoftware/OHHTTPStubs" ~> 6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,3 @@
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.7.8"
+github "AliSoftware/OHHTTPStubs" "6.1.0"
 github "raphaelmor/Polyline" "v5.1.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,1 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.7.8"
-github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "raphaelmor/Polyline" "v4.2.0"
+github "raphaelmor/Polyline" "v5.1.0"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,14 @@
-Copyright © 2014–2018, Mapbox
+The MIT License (MIT)
+
+Copyright (c) 2023 MapLibre contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Copyright © 2014–2023, Mapbox
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -1758,7 +1758,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "Directions Example/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Directions.Swift;
 				PRODUCT_MODULE_NAME = DirectionsExampleSwift;
@@ -1782,7 +1782,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "Directions Example/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Directions.Swift;
 				PRODUCT_MODULE_NAME = DirectionsExampleSwift;

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -1668,6 +1668,7 @@
 				);
 				INFOPLIST_FILE = MapboxDirections/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1696,6 +1697,7 @@
 				);
 				INFOPLIST_FILE = MapboxDirections/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1717,7 +1719,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = MapboxDirectionsTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(PROJECT_DIR)/Carthage/Build/iOS @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1735,7 +1737,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = MapboxDirectionsTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(PROJECT_DIR)/Carthage/Build/iOS @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-# MapboxDirections
+# MaplibreDirections
 
-[📱&nbsp;![iOS Build Status](https://app.bitrise.io/app/2f82077d3f083479/status.svg?token=mC783nGMKA3XrvcMCJAOLg&branch=master)](https://www.bitrise.io/app/2f82077d3f083479) &nbsp;&nbsp;&nbsp;
-[🖥💻&nbsp;![macOS Build Status](https://app.bitrise.io/app/3e18d5c284ee7fe4/status.svg?token=YCPg5FTvNCSoRBvECdFWtg&branch=master)](https://www.bitrise.io/app/3e18d5c284ee7fe4) &nbsp;&nbsp;&nbsp;
-[📺&nbsp;![tvOS Build Status](https://app.bitrise.io/app/0dd69f13a42252d6/status.svg?token=jin7-oeLn35GfZqWaqumtA&branch=master)](https://www.bitrise.io/app/0dd69f13a42252d6) &nbsp;&nbsp;&nbsp;
-[⌚️&nbsp;![watchOS Build Status](https://app.bitrise.io/app/6db52b89a8fbfb40/status.svg?token=v645xdLSJWX0uYxLU7CA3g&branch=master)](https://www.bitrise.io/app/6db52b89a8fbfb40) &nbsp;&nbsp;&nbsp;
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) &nbsp;&nbsp;&nbsp;
-[![CocoaPods](https://img.shields.io/cocoapods/v/MapboxDirections.swift.svg)](http://cocoadocs.org/docsets/MapboxDirections.swift/)
+Copyright (c) 2023 MapLibre contributors
+
+The MaplibreDirections SDK for iOS is built on a for of the MapboxDirections SDK v.023.
 
 MapboxDirections.swift makes it easy to connect your iOS, macOS, tvOS, or watchOS application to the [Mapbox Directions API](https://www.mapbox.com/directions/) and [Mapbox Map Matching API](https://www.mapbox.com/directions/). Quickly get driving, cycling, or walking directions, whether the trip is nonstop or it has multiple stopping points, all using a simple interface reminiscent of MapKit’s `MKDirections` API. Fit a GPX trace to the [OpenStreetMap](https://www.openstreetmap.org/) road network. The Mapbox Directions and Map Matching APIs are powered by the [OSRM](http://project-osrm.org/) routing engine.
 
@@ -13,7 +10,19 @@ Despite its name, MapboxDirections.swift works in Objective-C and Cocoa-AppleScr
 
 MapboxDirections.swift pairs well with [MapboxGeocoder.swift](https://github.com/mapbox/MapboxGeocoder.swift), [MapboxStatic.swift](https://github.com/mapbox/MapboxStatic.swift), the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/), and the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/).
 
+# Why have we forked
+
+1. We wanted to upgrade the SDK from iOS 9.0 to 12.0.
+
+# What have we changed
+
+- Upgrade iOS version from 9.0 to 12.0.
+- Upgraded Polyline SDK from v4.2.0 to v5.1.0. 
+- Removed private cartfile.
+
 ## Getting started
+
+If you are looking to include this inside your project, you have to follow the the following steps:
 
 Specify the following dependency in your [Carthage](https://github.com/Carthage/Carthage) Cartfile:
 

--- a/SECURITY_POLICY.txt
+++ b/SECURITY_POLICY.txt
@@ -1,0 +1,2 @@
+For an up-to-date policy refer to
+https://github.com/maplibre/maplibre/blob/main/SECURITY_POLICY.txt


### PR DESCRIPTION
https://github.com/maplibre/maplibre-directions-swift (currently at: https://github.com/flitsmeister/mapbox-directions-swift/)

## Motivation
From XCode 14.3 and on, the minimum deployment target for a framework and its dependencies need to be 12.0 or higher. The current Maplibre Navigation SDK uses a couple of dependencies that still use 8.0 as a minimum, this is one of them. Therefore we needed to fork this dependency and upgrade it to support iOS 12.0.

## Acceptance
- [ ] Any two board members must agree to accept a new repository.
  **Approved by:** <@user1> <@user2>

## Licensing
- [x] The repo license is BSD-3 or MIT.
  *Repos may allow dual-licensing under other open source licenses, e.g. MIT OR Apache.*
- [x] The repo contains `Copyright (c) <year> MapLibre contributors` in license file(s) and in the readme.

## Special files
- [x] `/README.md`
  *Description, link to the main maplibre.org page, name of the OSM-US Slack channel for discussions and an [invite link](https://slack.openstreetmap.us), etc*
- [x] `/LICENSE`
   *Dual-licensed repos may have additional files like `LICENSE-MIT` and `LICENSE-APACHE`*
- [x] `/SECURITY_POLICY.txt`
    Add the text:
    ```
    For an up-to-date policy refer to
    https://github.com/maplibre/maplibre/blob/main/SECURITY_POLICY.txt
    ```
- [x] `/CONTRIBUTING.md`
- [x] The repo has Pull Request and Issue Templates in `/.github` dir.
- [x] The repo has `/.github/FUNDING.yml` file copied from [maplibre-gl-js/funding](https://github.com/maplibre/maplibre-gl-js/blob/main/.github/FUNDING.yml)
- [x] `/CODE_OF_CONDUCT.md`
  *This file should only link to our [primary code of conduct](https://github.com/maplibre/maplibre/blob/main/CODE_OF_CONDUCT.md). Use this markup for consistency:*
 `# Contributor Covenant`
 `[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/maplibre/maplibre/blob/main/CODE_OF_CONDUCT.md)`

## Repo Settings
#### General page
- [x] **[Features]** Disable unused features like wiki.
- [x] **[Features]** Enable `Sponsorships` checkbox (see also FUNDING.yaml above).
- [x] **[Features]** Enable `Preserve this repository`.
- [x] **[Pull Requests]** Community is encouraged to use `squash merge`. Disable other merge types if possible.
- [x] **[Pull Requests]** Enable `Automatically delete head branches`.

#### Access
- [ ] The repo has at least one admin who is ideally not part of the Governing Board: <@user>

#### Branches
- [x] The primary branch is named `main`.
- [ ] Set up branch rules to require CI pass and an approval before merge.
  *For smaller projects it might be OK to ignore this rule.*

## Miscelaneous
- [ ] The repo must not have any personal branches.
  *All work should be done on forks and submitted via PRs, including by the admins.*
- [ ] Repo has a proper GitHub description and an optional web site
  *Use the gear icon in the upper right corner of the repo page.*
- [ ] CI automatically runs on all pull requests before merging using GitHub actions
- [ ] Grant admin rights to the board members and automation accounts for packages <list-of-packages>
  - [npmjs.com](https://www.npmjs.com/): package settings / invite:  `maplibreorg nyurik klokan lseelenbinder wipfli`
  - [crates.io](https://crates.io/): package settings / add owner: `nyurik klokan lseelenbinder wipfli`

## Community
- [ ] The new repo has been announced in the `#maplibre` OSMUS slack channel.
- [ ] The new repo has been announced in the next monthly meeting of the Technical Steering Committee.
- [ ] The new repo has been announced in the `@maplibre` twitter.
