### PR TITLE
Add leg notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Added support for route leg notifications, including alerts, violations, refresh behavior, subtypes, and notification details, following the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object). ([#8](https://github.com/flitsmeister/mapbox-directions-swift/pull/8))
+* Added support for route leg notifications (`RouteNotification`), including alerts, violations, refresh behavior, subtypes, and notification details, following the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object). ([#8](https://github.com/flitsmeister/mapbox-directions-swift/pull/8))
 
 ## v0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Directions SDK for iOS
 
+## Unreleased
+
+* Added support for route leg notifications, including alerts, violations, refresh behavior, subtypes, and notification details, following the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object). ([#TBD](https://github.com/flitsmeister/mapbox-directions-swift/pull/TBD))
+
 ## v0.23.0
 
 * Added `Waypoint.allowsArrivingOnOppositeSide` property for restricting the side of arrival. ([#288](https://github.com/mapbox/MapboxDirections.swift/pull/288))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Added support for route leg notifications, including alerts, violations, refresh behavior, subtypes, and notification details, following the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object). ([#TBD](https://github.com/flitsmeister/mapbox-directions-swift/pull/TBD))
+* Added support for route leg notifications, including alerts, violations, refresh behavior, subtypes, and notification details, following the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object). ([#8](https://github.com/flitsmeister/mapbox-directions-swift/pull/8))
 
 ## v0.23.0
 

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -77,6 +77,13 @@
 		C558C58E1E94196200617B37 /* MBAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = C558C58B1E94181A00617B37 /* MBAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C558C58F1E94196300617B37 /* MBAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = C558C58B1E94181A00617B37 /* MBAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C55FB44B1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */; };
+		A1B2C3D40100000200NOTIF1 /* MBNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBNotification.swift */; };
+		A1B2C3D40100000300NOTIF1 /* MBNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBNotification.swift */; };
+		A1B2C3D40100000400NOTIF1 /* MBNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBNotification.swift */; };
+		A1B2C3D40100000500NOTIF1 /* MBNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBNotification.swift */; };
+		A1B2C3D40100000700NOTIF1 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000600NOTIF1 /* NotificationTests.swift */; };
+		A1B2C3D40100000800NOTIF1 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000600NOTIF1 /* NotificationTests.swift */; };
+		A1B2C3D40100000900NOTIF1 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000600NOTIF1 /* NotificationTests.swift */; };
 		C56516841FE1A2DD00A0AD18 /* MBVisualInstructionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */; };
 		C56516851FE1AB8F00A0AD18 /* MBVisualInstructionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */; };
 		C56516861FE1AB9000A0AD18 /* MBVisualInstructionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */; };
@@ -291,6 +298,8 @@
 		C5434B8B200695A50069E887 /* MBMatchOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBMatchOptions.swift; sourceTree = "<group>"; };
 		C558C58B1E94181A00617B37 /* MBAttribute.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBAttribute.h; sourceTree = "<group>"; };
 		C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBSpokenInstruction.swift; sourceTree = "<group>"; };
+		A1B2C3D40100000100NOTIF1 /* MBNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBNotification.swift; sourceTree = "<group>"; };
+		A1B2C3D40100000600NOTIF1 /* NotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotificationTests.swift; path = MapboxDirectionsTests/NotificationTests.swift; sourceTree = SOURCE_ROOT; };
 		C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBVisualInstructionType.swift; sourceTree = "<group>"; };
 		C57B2E951DB8171300E9123A /* MBLaneIndication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBLaneIndication.h; sourceTree = "<group>"; };
 		C57D55001DB5669600B94B74 /* MBIntersection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBIntersection.swift; sourceTree = "<group>"; };
@@ -554,6 +563,7 @@
 				C584E3FA1F2027EE00BBC9BB /* MBRoadClasses.h */,
 				DA6C9D8C1CAE442B00094FBC /* Info.plist */,
 				C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */,
+				A1B2C3D40100000100NOTIF1 /* MBNotification.swift */,
 				C52552B81FA15D5900B1545C /* MBVisualInstructionBanner.swift */,
 				C52552BF1FA1628A00B1545C /* MBVisualInstructionComponent.swift */,
 				AEDC211C20B6104A0052DED8 /* MBComponentRepresentable.swift */,
@@ -569,6 +579,7 @@
 			children = (
 				F4D785EE1DDD82C100FF4665 /* RouteStepTests.swift */,
 				DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */,
+				A1B2C3D40100000600NOTIF1 /* NotificationTests.swift */,
 				DA1A110A1D01045E009F82FA /* DirectionsTests.swift */,
 				DA737EE71D0611CB005BDA16 /* V4Tests.swift */,
 				DA6C9DAB1CAEC72800094FBC /* V5Tests.swift */,
@@ -1173,6 +1184,7 @@
 				DA1A10CB1D00F969009F82FA /* MBRouteStep.swift in Sources */,
 				C57D55031DB566A700B94B74 /* MBIntersection.swift in Sources */,
 				C52CE38F1F6AF63C0069963D /* MBSpokenInstruction.swift in Sources */,
+				A1B2C3D40100000300NOTIF1 /* MBNotification.swift in Sources */,
 				C58EA7AB1E9D7F73008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6B1FDB3D8A008D5A58 /* String.swift in Sources */,
 				C56516851FE1AB8F00A0AD18 /* MBVisualInstructionType.swift in Sources */,
@@ -1189,6 +1201,7 @@
 			files = (
 				DAE9E0F51EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */,
 				C53A02291E92C27A009837BD /* AnnotationTests.swift in Sources */,
+				A1B2C3D40100000700NOTIF1 /* NotificationTests.swift in Sources */,
 				C596663A2048AECD00C45CE5 /* RoutableMatchTests.swift in Sources */,
 				DA1A10CD1D00F972009F82FA /* V5Tests.swift in Sources */,
 				DA737EE91D0611CB005BDA16 /* V4Tests.swift in Sources */,
@@ -1225,6 +1238,7 @@
 				DA1A10F11D010247009F82FA /* MBRouteStep.swift in Sources */,
 				C57D55041DB566A800B94B74 /* MBIntersection.swift in Sources */,
 				C52CE3901F6AF63D0069963D /* MBSpokenInstruction.swift in Sources */,
+				A1B2C3D40100000400NOTIF1 /* MBNotification.swift in Sources */,
 				C58EA7AC1E9D7F74008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6C1FDB3D8B008D5A58 /* String.swift in Sources */,
 				C56516861FE1AB9000A0AD18 /* MBVisualInstructionType.swift in Sources */,
@@ -1241,6 +1255,7 @@
 			files = (
 				DAE9E0F61EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */,
 				C53A022A1E92C27B009837BD /* AnnotationTests.swift in Sources */,
+				A1B2C3D40100000800NOTIF1 /* NotificationTests.swift in Sources */,
 				C596663B2048AECE00C45CE5 /* RoutableMatchTests.swift in Sources */,
 				DA1A10F41D010251009F82FA /* V5Tests.swift in Sources */,
 				DA737EEA1D0611CB005BDA16 /* V4Tests.swift in Sources */,
@@ -1277,6 +1292,7 @@
 				DA1A11081D0103A3009F82FA /* MBRouteStep.swift in Sources */,
 				C57D55051DB566A900B94B74 /* MBIntersection.swift in Sources */,
 				C52CE3911F6AF63E0069963D /* MBSpokenInstruction.swift in Sources */,
+				A1B2C3D40100000500NOTIF1 /* MBNotification.swift in Sources */,
 				C58EA7AD1E9D7F75008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6D1FDB3D8B008D5A58 /* String.swift in Sources */,
 				C56516871FE1AB9100A0AD18 /* MBVisualInstructionType.swift in Sources */,
@@ -1311,6 +1327,7 @@
 				C5434B8A200693D00069E887 /* MBTracepoint.swift in Sources */,
 				DA6C9DA61CAE462800094FBC /* MBDirections.swift in Sources */,
 				C55FB44B1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift in Sources */,
+				A1B2C3D40100000200NOTIF1 /* MBNotification.swift in Sources */,
 				C5DAAC9A20191675001F9261 /* MBMatch.swift in Sources */,
 				C58EA7AA1E9D7EAD008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6A1FDB101F008D5A58 /* String.swift in Sources */,
@@ -1327,6 +1344,7 @@
 			files = (
 				DAE9E0F41EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */,
 				C5247D711E818A24004B6154 /* AnnotationTests.swift in Sources */,
+				A1B2C3D40100000900NOTIF1 /* NotificationTests.swift in Sources */,
 				C59666392048A20E00C45CE5 /* RoutableMatchTests.swift in Sources */,
 				DA6C9DAC1CAEC72800094FBC /* V5Tests.swift in Sources */,
 				DA737EE81D0611CB005BDA16 /* V4Tests.swift in Sources */,

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -77,10 +77,10 @@
 		C558C58E1E94196200617B37 /* MBAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = C558C58B1E94181A00617B37 /* MBAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C558C58F1E94196300617B37 /* MBAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = C558C58B1E94181A00617B37 /* MBAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C55FB44B1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */; };
-		A1B2C3D40100000200NOTIF1 /* MBNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBNotification.swift */; };
-		A1B2C3D40100000300NOTIF1 /* MBNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBNotification.swift */; };
-		A1B2C3D40100000400NOTIF1 /* MBNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBNotification.swift */; };
-		A1B2C3D40100000500NOTIF1 /* MBNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBNotification.swift */; };
+		A1B2C3D40100000200NOTIF1 /* MBRouteNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBRouteNotification.swift */; };
+		A1B2C3D40100000300NOTIF1 /* MBRouteNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBRouteNotification.swift */; };
+		A1B2C3D40100000400NOTIF1 /* MBRouteNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBRouteNotification.swift */; };
+		A1B2C3D40100000500NOTIF1 /* MBRouteNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000100NOTIF1 /* MBRouteNotification.swift */; };
 		A1B2C3D40100000700NOTIF1 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000600NOTIF1 /* NotificationTests.swift */; };
 		A1B2C3D40100000800NOTIF1 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000600NOTIF1 /* NotificationTests.swift */; };
 		A1B2C3D40100000900NOTIF1 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40100000600NOTIF1 /* NotificationTests.swift */; };
@@ -298,7 +298,7 @@
 		C5434B8B200695A50069E887 /* MBMatchOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBMatchOptions.swift; sourceTree = "<group>"; };
 		C558C58B1E94181A00617B37 /* MBAttribute.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBAttribute.h; sourceTree = "<group>"; };
 		C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBSpokenInstruction.swift; sourceTree = "<group>"; };
-		A1B2C3D40100000100NOTIF1 /* MBNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBNotification.swift; sourceTree = "<group>"; };
+		A1B2C3D40100000100NOTIF1 /* MBRouteNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBRouteNotification.swift; sourceTree = "<group>"; };
 		A1B2C3D40100000600NOTIF1 /* NotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotificationTests.swift; path = MapboxDirectionsTests/NotificationTests.swift; sourceTree = SOURCE_ROOT; };
 		C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBVisualInstructionType.swift; sourceTree = "<group>"; };
 		C57B2E951DB8171300E9123A /* MBLaneIndication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBLaneIndication.h; sourceTree = "<group>"; };
@@ -563,7 +563,7 @@
 				C584E3FA1F2027EE00BBC9BB /* MBRoadClasses.h */,
 				DA6C9D8C1CAE442B00094FBC /* Info.plist */,
 				C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */,
-				A1B2C3D40100000100NOTIF1 /* MBNotification.swift */,
+				A1B2C3D40100000100NOTIF1 /* MBRouteNotification.swift */,
 				C52552B81FA15D5900B1545C /* MBVisualInstructionBanner.swift */,
 				C52552BF1FA1628A00B1545C /* MBVisualInstructionComponent.swift */,
 				AEDC211C20B6104A0052DED8 /* MBComponentRepresentable.swift */,
@@ -1184,7 +1184,7 @@
 				DA1A10CB1D00F969009F82FA /* MBRouteStep.swift in Sources */,
 				C57D55031DB566A700B94B74 /* MBIntersection.swift in Sources */,
 				C52CE38F1F6AF63C0069963D /* MBSpokenInstruction.swift in Sources */,
-				A1B2C3D40100000300NOTIF1 /* MBNotification.swift in Sources */,
+				A1B2C3D40100000300NOTIF1 /* MBRouteNotification.swift in Sources */,
 				C58EA7AB1E9D7F73008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6B1FDB3D8A008D5A58 /* String.swift in Sources */,
 				C56516851FE1AB8F00A0AD18 /* MBVisualInstructionType.swift in Sources */,
@@ -1238,7 +1238,7 @@
 				DA1A10F11D010247009F82FA /* MBRouteStep.swift in Sources */,
 				C57D55041DB566A800B94B74 /* MBIntersection.swift in Sources */,
 				C52CE3901F6AF63D0069963D /* MBSpokenInstruction.swift in Sources */,
-				A1B2C3D40100000400NOTIF1 /* MBNotification.swift in Sources */,
+				A1B2C3D40100000400NOTIF1 /* MBRouteNotification.swift in Sources */,
 				C58EA7AC1E9D7F74008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6C1FDB3D8B008D5A58 /* String.swift in Sources */,
 				C56516861FE1AB9000A0AD18 /* MBVisualInstructionType.swift in Sources */,
@@ -1292,7 +1292,7 @@
 				DA1A11081D0103A3009F82FA /* MBRouteStep.swift in Sources */,
 				C57D55051DB566A900B94B74 /* MBIntersection.swift in Sources */,
 				C52CE3911F6AF63E0069963D /* MBSpokenInstruction.swift in Sources */,
-				A1B2C3D40100000500NOTIF1 /* MBNotification.swift in Sources */,
+				A1B2C3D40100000500NOTIF1 /* MBRouteNotification.swift in Sources */,
 				C58EA7AD1E9D7F75008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6D1FDB3D8B008D5A58 /* String.swift in Sources */,
 				C56516871FE1AB9100A0AD18 /* MBVisualInstructionType.swift in Sources */,
@@ -1327,7 +1327,7 @@
 				C5434B8A200693D00069E887 /* MBTracepoint.swift in Sources */,
 				DA6C9DA61CAE462800094FBC /* MBDirections.swift in Sources */,
 				C55FB44B1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift in Sources */,
-				A1B2C3D40100000200NOTIF1 /* MBNotification.swift in Sources */,
+				A1B2C3D40100000200NOTIF1 /* MBRouteNotification.swift in Sources */,
 				C5DAAC9A20191675001F9261 /* MBMatch.swift in Sources */,
 				C58EA7AA1E9D7EAD008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6A1FDB101F008D5A58 /* String.swift in Sources */,

--- a/MapboxDirections/MBNotification.swift
+++ b/MapboxDirections/MBNotification.swift
@@ -1,0 +1,479 @@
+import Foundation
+
+/**
+ The type of a route leg notification.
+
+ Notification types supported by the Directions API are `violation` and `alert`.
+ `violation` is more severe and is delivered when user-set parameters (for example `exclude=unpaved`)
+ are violated during route generation. `alert` is less severe and informs users when implicit
+ preferences cannot be satisfied (for example `countryBorderCrossing`).
+
+ Unknown values are preserved for forward compatibility.
+ */
+@objc(MBNotificationType)
+public enum NotificationType: Int, CustomStringConvertible {
+    /**
+     An alert that is relevant to a route leg.
+     */
+    case alert
+
+    /**
+     The route leg violates a restriction.
+     */
+    case violation
+
+    /**
+     An unrecognized notification type returned by the Directions API.
+     */
+    case unknown
+
+    public init(description: String) {
+        switch description {
+        case "alert":
+            self = .alert
+        case "violation":
+            self = .violation
+        default:
+            self = .unknown
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .alert:
+            return "alert"
+        case .violation:
+            return "violation"
+        case .unknown:
+            return "unknown"
+        }
+    }
+}
+
+/**
+ The optional subtype of a route leg notification.
+
+ Unknown values are preserved for forward compatibility via `rawValue`.
+ */
+public struct NotificationSubtype: RawRepresentable, Hashable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String {
+        return rawValue
+    }
+
+    /**
+     `type=violation` — The height of the vehicle is greater than the allowed height of the road.
+     Provided when `max_height` is specified.
+     */
+    public static let maxHeight = NotificationSubtype(rawValue: "maxHeight")
+
+    /**
+     `type=violation` — The width of the vehicle is greater than the allowed width of the road.
+     Provided when `max_width` is specified.
+     */
+    public static let maxWidth = NotificationSubtype(rawValue: "maxWidth")
+
+    /**
+     `type=violation` — The weight of the vehicle is greater than the allowed weight of the road.
+     Provided when `max_weight` is specified.
+     */
+    public static let maxWeight = NotificationSubtype(rawValue: "maxWeight")
+
+    /**
+     `type=violation` — Unpaved road, while it was explicitly requested to exclude unpaved roads.
+     Provided when `exclude=unpaved`.
+     */
+    public static let unpaved = NotificationSubtype(rawValue: "unpaved")
+
+    /**
+     `type=violation` — Road with tunnel, while it was explicitly requested to exclude tunnels.
+     `type=alert` — Indicates a tunnel is on the route.
+     */
+    public static let tunnel = NotificationSubtype(rawValue: "tunnel")
+
+    /**
+     `type=violation` — Toll road, while it was explicitly requested to exclude toll roads.
+     `type=alert` — Indicates a toll road is on the route.
+     */
+    public static let toll = NotificationSubtype(rawValue: "toll")
+
+    /**
+     `type=violation` — Undesirable road excluded by point.
+     Provided when `exclude=point(longitude latitude)`.
+     */
+    public static let pointExclusion = NotificationSubtype(rawValue: "pointExclusion")
+
+    /**
+     `type=violation` / `type=alert` — Indicates a country border crossing.
+     */
+    public static let countryBorderCrossing = NotificationSubtype(rawValue: "countryBorderCrossing")
+
+    /**
+     `type=violation` / `type=alert` — Indicates a state border crossing.
+     */
+    public static let stateBorderCrossing = NotificationSubtype(rawValue: "stateBorderCrossing")
+
+    /**
+     `type=violation` — Indicates a ferry crossing. Provided when `exclude=ferry`.
+     */
+    public static let ferry = NotificationSubtype(rawValue: "ferry")
+}
+
+/**
+ The refresh type of a notification, distinguishing static and dynamic notifications.
+
+ Unknown values are preserved for forward compatibility via `rawValue`.
+ */
+public struct NotificationRefreshType: RawRepresentable, Hashable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String {
+        return rawValue
+    }
+
+    /**
+     A notification received with the initial route request or a refresh, then kept constant.
+     */
+    public static let `static` = NotificationRefreshType(rawValue: "static")
+
+    /**
+     A notification that is updated and reset with each route refresh.
+     */
+    public static let dynamic = NotificationRefreshType(rawValue: "dynamic")
+}
+
+/**
+ The reason why a notification was issued.
+ */
+public struct NotificationReason: RawRepresentable, Hashable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String {
+        return rawValue
+    }
+
+    public static let outOfOrder = NotificationReason(rawValue: "outOfOrder")
+    public static let occupied = NotificationReason(rawValue: "occupied")
+}
+
+/**
+ Details specific to a notification type and subtype.
+
+ See the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object).
+ */
+@objc(MBNotificationDetails)
+open class NotificationDetails: NSObject, NSSecureCoding {
+
+    /**
+     The optional requested value in the request.
+
+     For example, it is `"3"` (meters) if `max_width=3` was specified in the request.
+     */
+    @objc public let requestedValue: String?
+
+    /**
+     The optional actual value associated with the property of the road.
+
+     For example, it is `"2.5"` (meters) if the maximum road width is 2.5 meters.
+     */
+    @objc public let actualValue: String?
+
+    /**
+     The optional unit of measure associated with `actualValue` and `requestedValue`.
+     */
+    @objc public let unit: String?
+
+    /**
+     The optional message associated with the notification.
+     */
+    @objc public let message: String?
+
+    /**
+     Initializes notification details with the given values.
+     */
+    @objc public init(requestedValue: String? = nil, actualValue: String? = nil, unit: String? = nil, message: String? = nil) {
+        self.requestedValue = requestedValue
+        self.actualValue = actualValue
+        self.unit = unit
+        self.message = message
+    }
+
+    /**
+     Initializes notification details from a JSON dictionary representation.
+     */
+    @objc(initWithJSON:)
+    public convenience init(json: [String: Any]) {
+        self.init(
+            requestedValue: NotificationDetails.stringValue(from: json["requested_value"]),
+            actualValue: NotificationDetails.stringValue(from: json["actual_value"]),
+            unit: json["unit"] as? String,
+            message: json["message"] as? String
+        )
+    }
+
+    public required init?(coder decoder: NSCoder) {
+        requestedValue = decoder.decodeObject(of: NSString.self, forKey: "requestedValue") as String?
+        actualValue = decoder.decodeObject(of: NSString.self, forKey: "actualValue") as String?
+        unit = decoder.decodeObject(of: NSString.self, forKey: "unit") as String?
+        message = decoder.decodeObject(of: NSString.self, forKey: "message") as String?
+    }
+
+    @objc public static var supportsSecureCoding = true
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(requestedValue, forKey: "requestedValue")
+        coder.encode(actualValue, forKey: "actualValue")
+        coder.encode(unit, forKey: "unit")
+        coder.encode(message, forKey: "message")
+    }
+
+    /**
+     A JSON dictionary representation using Directions API wire names.
+     */
+    public var json: [String: Any] {
+        var dictionary: [String: Any] = [:]
+        if let requestedValue = requestedValue {
+            dictionary["requested_value"] = requestedValue
+        }
+        if let actualValue = actualValue {
+            dictionary["actual_value"] = actualValue
+        }
+        if let unit = unit {
+            dictionary["unit"] = unit
+        }
+        if let message = message {
+            dictionary["message"] = message
+        }
+        return dictionary
+    }
+
+    private static func stringValue(from value: Any?) -> String? {
+        switch value {
+        case let string as String:
+            return string
+        case let number as NSNumber:
+            return number.stringValue
+        default:
+            return nil
+        }
+    }
+}
+
+/**
+ A notification that is relevant to a route leg.
+
+ According to the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object).
+ */
+@objc(MBNotification)
+open class Notification: NSObject, NSSecureCoding {
+
+    /**
+     The type of notification (`alert` or `violation`).
+
+     Unknown API values are exposed as `.unknown`; use `typeDescription` for the original wire value.
+     */
+    @objc public let type: NotificationType
+
+    /**
+     The original `type` string from the Directions API response.
+
+     Preserved for forward compatibility when `type` is `.unknown`.
+     */
+    @objc public let typeDescription: String
+
+    /**
+     The optional subtype of the notification.
+
+     Known values include `ferry`, `maxWidth`, `countryBorderCrossing`, and others defined by `NotificationSubtype`.
+     */
+    public let subtype: NotificationSubtype?
+
+    /**
+     The ObjC-compatible subtype string, if any.
+     */
+    @objc public var subtypeDescription: String? {
+        return subtype?.rawValue
+    }
+
+    /**
+     The refresh type distinguishing static and dynamic notifications.
+     */
+    public let refreshType: NotificationRefreshType
+
+    /**
+     The ObjC-compatible refresh type string.
+     */
+    @objc public var refreshTypeDescription: String {
+        return refreshType.rawValue
+    }
+
+    /**
+     The optional position in the coordinate list where the notification occurred, relative to the start of the leg.
+     */
+    public let geometryIndex: Int?
+
+    /**
+     The optional position in the coordinate list where the notification began, relative to the start of the leg.
+     */
+    public let geometryIndexStart: Int?
+
+    /**
+     The optional position in the coordinate list where the notification ended, relative to the start of the leg.
+     */
+    public let geometryIndexEnd: Int?
+
+    /**
+     The optional details specific to the notification type and subtype.
+     */
+    @objc public let details: NotificationDetails?
+
+    /**
+     Initializes a notification with the given values.
+     */
+    public init(type: NotificationType,
+                typeDescription: String? = nil,
+                subtype: NotificationSubtype? = nil,
+                refreshType: NotificationRefreshType,
+                geometryIndex: Int? = nil,
+                geometryIndexStart: Int? = nil,
+                geometryIndexEnd: Int? = nil,
+                details: NotificationDetails? = nil) {
+        self.type = type
+        self.typeDescription = typeDescription ?? type.description
+        self.subtype = subtype
+        self.refreshType = refreshType
+        self.geometryIndex = geometryIndex
+        self.geometryIndexStart = geometryIndexStart
+        self.geometryIndexEnd = geometryIndexEnd
+        self.details = details
+    }
+
+    /**
+     Initializes a notification from a JSON dictionary representation.
+
+     Returns `nil` if required fields `type` or `refresh_type` are missing.
+     */
+    @objc(initWithJSON:)
+    public convenience init?(json: [String: Any]) {
+        guard let typeString = json["type"] as? String,
+              let refreshTypeString = json["refresh_type"] as? String else {
+            return nil
+        }
+
+        let subtype: NotificationSubtype?
+        if let subtypeString = json["subtype"] as? String {
+            subtype = NotificationSubtype(rawValue: subtypeString)
+        } else {
+            subtype = nil
+        }
+
+        let details: NotificationDetails?
+        if let detailsJSON = json["details"] as? [String: Any] {
+            details = NotificationDetails(json: detailsJSON)
+        } else {
+            details = nil
+        }
+
+        self.init(
+            type: NotificationType(description: typeString),
+            typeDescription: typeString,
+            subtype: subtype,
+            refreshType: NotificationRefreshType(rawValue: refreshTypeString),
+            geometryIndex: json["geometry_index"] as? Int,
+            geometryIndexStart: json["geometry_index_start"] as? Int,
+            geometryIndexEnd: json["geometry_index_end"] as? Int,
+            details: details
+        )
+    }
+
+    public required init?(coder decoder: NSCoder) {
+        guard let typeDescription = decoder.decodeObject(of: NSString.self, forKey: "typeDescription") as String?,
+              let refreshTypeDescription = decoder.decodeObject(of: NSString.self, forKey: "refreshType") as String? else {
+            return nil
+        }
+
+        type = NotificationType(description: typeDescription)
+        self.typeDescription = typeDescription
+        if let subtypeDescription = decoder.decodeObject(of: NSString.self, forKey: "subtype") as String? {
+            subtype = NotificationSubtype(rawValue: subtypeDescription)
+        } else {
+            subtype = nil
+        }
+        refreshType = NotificationRefreshType(rawValue: refreshTypeDescription)
+
+        if decoder.containsValue(forKey: "geometryIndex") {
+            geometryIndex = decoder.decodeInteger(forKey: "geometryIndex")
+        } else {
+            geometryIndex = nil
+        }
+        if decoder.containsValue(forKey: "geometryIndexStart") {
+            geometryIndexStart = decoder.decodeInteger(forKey: "geometryIndexStart")
+        } else {
+            geometryIndexStart = nil
+        }
+        if decoder.containsValue(forKey: "geometryIndexEnd") {
+            geometryIndexEnd = decoder.decodeInteger(forKey: "geometryIndexEnd")
+        } else {
+            geometryIndexEnd = nil
+        }
+
+        details = decoder.decodeObject(of: NotificationDetails.self, forKey: "details")
+    }
+
+    @objc public static var supportsSecureCoding = true
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(typeDescription, forKey: "typeDescription")
+        coder.encode(subtype?.rawValue, forKey: "subtype")
+        coder.encode(refreshType.rawValue, forKey: "refreshType")
+        if let geometryIndex = geometryIndex {
+            coder.encode(geometryIndex, forKey: "geometryIndex")
+        }
+        if let geometryIndexStart = geometryIndexStart {
+            coder.encode(geometryIndexStart, forKey: "geometryIndexStart")
+        }
+        if let geometryIndexEnd = geometryIndexEnd {
+            coder.encode(geometryIndexEnd, forKey: "geometryIndexEnd")
+        }
+        coder.encode(details, forKey: "details")
+    }
+
+    /**
+     A JSON dictionary representation using Directions API wire names.
+     */
+    public var json: [String: Any] {
+        var dictionary: [String: Any] = [
+            "type": typeDescription,
+            "refresh_type": refreshType.rawValue
+        ]
+        if let subtype = subtype {
+            dictionary["subtype"] = subtype.rawValue
+        }
+        if let geometryIndex = geometryIndex {
+            dictionary["geometry_index"] = geometryIndex
+        }
+        if let geometryIndexStart = geometryIndexStart {
+            dictionary["geometry_index_start"] = geometryIndexStart
+        }
+        if let geometryIndexEnd = geometryIndexEnd {
+            dictionary["geometry_index_end"] = geometryIndexEnd
+        }
+        if let details = details {
+            dictionary["details"] = details.json
+        }
+        return dictionary
+    }
+}

--- a/MapboxDirections/MBNotification.swift
+++ b/MapboxDirections/MBNotification.swift
@@ -8,46 +8,28 @@ import Foundation
  are violated during route generation. `alert` is less severe and informs users when implicit
  preferences cannot be satisfied (for example `countryBorderCrossing`).
 
- Unknown values are preserved for forward compatibility.
+ Unknown values are preserved for forward compatibility via `rawValue`.
  */
-@objc(MBNotificationType)
-public enum NotificationType: Int, CustomStringConvertible {
+public struct NotificationType: RawRepresentable, Hashable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String {
+        return rawValue
+    }
+
     /**
      An alert that is relevant to a route leg.
      */
-    case alert
+    public static let alert = NotificationType(rawValue: "alert")
 
     /**
      The route leg violates a restriction.
      */
-    case violation
-
-    /**
-     An unrecognized notification type returned by the Directions API.
-     */
-    case unknown
-
-    public init(description: String) {
-        switch description {
-        case "alert":
-            self = .alert
-        case "violation":
-            self = .violation
-        default:
-            self = .unknown
-        }
-    }
-
-    public var description: String {
-        switch self {
-        case .alert:
-            return "alert"
-        case .violation:
-            return "violation"
-        case .unknown:
-            return "unknown"
-        }
-    }
+    public static let violation = NotificationType(rawValue: "violation")
 }
 
 /**
@@ -174,37 +156,36 @@ public struct NotificationReason: RawRepresentable, Hashable, CustomStringConver
 
  See the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object).
  */
-@objc(MBNotificationDetails)
-open class NotificationDetails: NSObject, NSSecureCoding {
+public final class NotificationDetails: NSObject, NSSecureCoding {
 
     /**
      The optional requested value in the request.
 
      For example, it is `"3"` (meters) if `max_width=3` was specified in the request.
      */
-    @objc public let requestedValue: String?
+    public let requestedValue: String?
 
     /**
      The optional actual value associated with the property of the road.
 
      For example, it is `"2.5"` (meters) if the maximum road width is 2.5 meters.
      */
-    @objc public let actualValue: String?
+    public let actualValue: String?
 
     /**
      The optional unit of measure associated with `actualValue` and `requestedValue`.
      */
-    @objc public let unit: String?
+    public let unit: String?
 
     /**
      The optional message associated with the notification.
      */
-    @objc public let message: String?
+    public let message: String?
 
     /**
      Initializes notification details with the given values.
      */
-    @objc public init(requestedValue: String? = nil, actualValue: String? = nil, unit: String? = nil, message: String? = nil) {
+    public init(requestedValue: String? = nil, actualValue: String? = nil, unit: String? = nil, message: String? = nil) {
         self.requestedValue = requestedValue
         self.actualValue = actualValue
         self.unit = unit
@@ -214,7 +195,6 @@ open class NotificationDetails: NSObject, NSSecureCoding {
     /**
      Initializes notification details from a JSON dictionary representation.
      */
-    @objc(initWithJSON:)
     public convenience init(json: [String: Any]) {
         self.init(
             requestedValue: NotificationDetails.stringValue(from: json["requested_value"]),
@@ -231,7 +211,7 @@ open class NotificationDetails: NSObject, NSSecureCoding {
         message = decoder.decodeObject(of: NSString.self, forKey: "message") as String?
     }
 
-    @objc public static var supportsSecureCoding = true
+    public static var supportsSecureCoding = true
 
     public func encode(with coder: NSCoder) {
         coder.encode(requestedValue, forKey: "requestedValue")
@@ -277,22 +257,14 @@ open class NotificationDetails: NSObject, NSSecureCoding {
 
  According to the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object).
  */
-@objc(MBNotification)
-open class Notification: NSObject, NSSecureCoding {
+public final class Notification: NSObject, NSSecureCoding {
 
     /**
      The type of notification (`alert` or `violation`).
 
-     Unknown API values are exposed as `.unknown`; use `typeDescription` for the original wire value.
+     Unknown API values are preserved in `rawValue`.
      */
-    @objc public let type: NotificationType
-
-    /**
-     The original `type` string from the Directions API response.
-
-     Preserved for forward compatibility when `type` is `.unknown`.
-     */
-    @objc public let typeDescription: String
+    public let type: NotificationType
 
     /**
      The optional subtype of the notification.
@@ -302,23 +274,9 @@ open class Notification: NSObject, NSSecureCoding {
     public let subtype: NotificationSubtype?
 
     /**
-     The ObjC-compatible subtype string, if any.
-     */
-    @objc public var subtypeDescription: String? {
-        return subtype?.rawValue
-    }
-
-    /**
      The refresh type distinguishing static and dynamic notifications.
      */
     public let refreshType: NotificationRefreshType
-
-    /**
-     The ObjC-compatible refresh type string.
-     */
-    @objc public var refreshTypeDescription: String {
-        return refreshType.rawValue
-    }
 
     /**
      The optional position in the coordinate list where the notification occurred, relative to the start of the leg.
@@ -338,13 +296,12 @@ open class Notification: NSObject, NSSecureCoding {
     /**
      The optional details specific to the notification type and subtype.
      */
-    @objc public let details: NotificationDetails?
+    public let details: NotificationDetails?
 
     /**
      Initializes a notification with the given values.
      */
     public init(type: NotificationType,
-                typeDescription: String? = nil,
                 subtype: NotificationSubtype? = nil,
                 refreshType: NotificationRefreshType,
                 geometryIndex: Int? = nil,
@@ -352,7 +309,6 @@ open class Notification: NSObject, NSSecureCoding {
                 geometryIndexEnd: Int? = nil,
                 details: NotificationDetails? = nil) {
         self.type = type
-        self.typeDescription = typeDescription ?? type.description
         self.subtype = subtype
         self.refreshType = refreshType
         self.geometryIndex = geometryIndex
@@ -366,7 +322,6 @@ open class Notification: NSObject, NSSecureCoding {
 
      Returns `nil` if required fields `type` or `refresh_type` are missing.
      */
-    @objc(initWithJSON:)
     public convenience init?(json: [String: Any]) {
         guard let typeString = json["type"] as? String,
               let refreshTypeString = json["refresh_type"] as? String else {
@@ -388,8 +343,7 @@ open class Notification: NSObject, NSSecureCoding {
         }
 
         self.init(
-            type: NotificationType(description: typeString),
-            typeDescription: typeString,
+            type: NotificationType(rawValue: typeString),
             subtype: subtype,
             refreshType: NotificationRefreshType(rawValue: refreshTypeString),
             geometryIndex: json["geometry_index"] as? Int,
@@ -400,19 +354,18 @@ open class Notification: NSObject, NSSecureCoding {
     }
 
     public required init?(coder decoder: NSCoder) {
-        guard let typeDescription = decoder.decodeObject(of: NSString.self, forKey: "typeDescription") as String?,
-              let refreshTypeDescription = decoder.decodeObject(of: NSString.self, forKey: "refreshType") as String? else {
+        guard let typeRawValue = decoder.decodeObject(of: NSString.self, forKey: "type") as String?,
+              let refreshTypeRawValue = decoder.decodeObject(of: NSString.self, forKey: "refreshType") as String? else {
             return nil
         }
 
-        type = NotificationType(description: typeDescription)
-        self.typeDescription = typeDescription
-        if let subtypeDescription = decoder.decodeObject(of: NSString.self, forKey: "subtype") as String? {
-            subtype = NotificationSubtype(rawValue: subtypeDescription)
+        type = NotificationType(rawValue: typeRawValue)
+        if let subtypeRawValue = decoder.decodeObject(of: NSString.self, forKey: "subtype") as String? {
+            subtype = NotificationSubtype(rawValue: subtypeRawValue)
         } else {
             subtype = nil
         }
-        refreshType = NotificationRefreshType(rawValue: refreshTypeDescription)
+        refreshType = NotificationRefreshType(rawValue: refreshTypeRawValue)
 
         if decoder.containsValue(forKey: "geometryIndex") {
             geometryIndex = decoder.decodeInteger(forKey: "geometryIndex")
@@ -433,10 +386,10 @@ open class Notification: NSObject, NSSecureCoding {
         details = decoder.decodeObject(of: NotificationDetails.self, forKey: "details")
     }
 
-    @objc public static var supportsSecureCoding = true
+    public static var supportsSecureCoding = true
 
     public func encode(with coder: NSCoder) {
-        coder.encode(typeDescription, forKey: "typeDescription")
+        coder.encode(type.rawValue, forKey: "type")
         coder.encode(subtype?.rawValue, forKey: "subtype")
         coder.encode(refreshType.rawValue, forKey: "refreshType")
         if let geometryIndex = geometryIndex {
@@ -456,7 +409,7 @@ open class Notification: NSObject, NSSecureCoding {
      */
     public var json: [String: Any] {
         var dictionary: [String: Any] = [
-            "type": typeDescription,
+            "type": type.rawValue,
             "refresh_type": refreshType.rawValue
         ]
         if let subtype = subtype {

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -47,6 +47,12 @@ open class RouteLeg: NSObject, NSSecureCoding {
         self.expectedSegmentTravelTimes = expectedSegmentTravelTimes
         self.segmentSpeeds = segmentSpeeds
         self.segmentCongestionLevels = congestionLevels
+
+        if let notificationsJSON = json["notifications"] as? [JSONDictionary] {
+            notifications = notificationsJSON.compactMap { Notification(json: $0) }
+        } else {
+            notifications = []
+        }
     }
     
     /**
@@ -95,6 +101,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
         expectedSegmentTravelTimes = decoder.decodeObject(of: [NSArray.self, NSNumber.self], forKey: "expectedSegmentTravelTimes") as? [TimeInterval]
         segmentSpeeds = decoder.decodeObject(of: [NSArray.self, NSNumber.self], forKey: "segmentSpeeds") as? [CLLocationSpeed]
         segmentCongestionLevels = decoder.decodeObject(of: [NSArray.self, NSNumber.self], forKey: "segmentCongestionLevels") as? [CongestionLevel]
+        notifications = decoder.decodeObject(of: [NSArray.self, Notification.self], forKey: "notifications") as? [Notification] ?? []
     }
     
     @objc public static var supportsSecureCoding = true
@@ -111,6 +118,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
         coder.encode(expectedSegmentTravelTimes, forKey: "expectedSegmentTravelTimes")
         coder.encode(segmentSpeeds, forKey: "segmentSpeeds")
         coder.encode(segmentCongestionLevels, forKey: "segmentCongestionLevels")
+        coder.encode(notifications, forKey: "notifications")
     }
     
     // MARK: Getting the Leg Geometry
@@ -174,6 +182,17 @@ open class RouteLeg: NSObject, NSSecureCoding {
      This property is set if the `RouteOptions.attributeOptions` property contains `.congestionLevel`.
      */
     public let segmentCongestionLevels: [CongestionLevel]?
+
+    /**
+     An array of notifications that are relevant to this route leg.
+
+     Notifications can warn drivers of potential risks or restrictions along the route, such as ferry
+     crossings, toll roads, or vehicle dimension violations. See the
+     [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object).
+
+     Defaults to an empty array when the Directions API response does not include notifications.
+     */
+    @objc public let notifications: [Notification]
     
     // MARK: Getting Additional Leg Details
     

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -49,7 +49,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
         self.segmentCongestionLevels = congestionLevels
 
         if let notificationsJSON = json["notifications"] as? [JSONDictionary] {
-            notifications = notificationsJSON.compactMap { Notification(json: $0) }
+            notifications = notificationsJSON.compactMap { RouteNotification(json: $0) }
         } else {
             notifications = []
         }
@@ -101,7 +101,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
         expectedSegmentTravelTimes = decoder.decodeObject(of: [NSArray.self, NSNumber.self], forKey: "expectedSegmentTravelTimes") as? [TimeInterval]
         segmentSpeeds = decoder.decodeObject(of: [NSArray.self, NSNumber.self], forKey: "segmentSpeeds") as? [CLLocationSpeed]
         segmentCongestionLevels = decoder.decodeObject(of: [NSArray.self, NSNumber.self], forKey: "segmentCongestionLevels") as? [CongestionLevel]
-        notifications = decoder.decodeObject(of: [NSArray.self, Notification.self], forKey: "notifications") as? [Notification] ?? []
+        notifications = decoder.decodeObject(of: [NSArray.self, RouteNotification.self], forKey: "notifications") as? [RouteNotification] ?? []
     }
     
     @objc public static var supportsSecureCoding = true
@@ -192,7 +192,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
 
      Defaults to an empty array when the Directions API response does not include notifications.
      */
-    public let notifications: [Notification]
+    public let notifications: [RouteNotification]
     
     // MARK: Getting Additional Leg Details
     

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -192,7 +192,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
 
      Defaults to an empty array when the Directions API response does not include notifications.
      */
-    @objc public let notifications: [Notification]
+    public let notifications: [Notification]
     
     // MARK: Getting Additional Leg Details
     

--- a/MapboxDirections/MBRouteNotification.swift
+++ b/MapboxDirections/MBRouteNotification.swift
@@ -10,7 +10,7 @@ import Foundation
 
  Unknown values are preserved for forward compatibility via `rawValue`.
  */
-public struct NotificationType: RawRepresentable, Hashable, CustomStringConvertible {
+public struct RouteNotificationType: RawRepresentable, Hashable, CustomStringConvertible {
     public let rawValue: String
 
     public init(rawValue: String) {
@@ -24,12 +24,12 @@ public struct NotificationType: RawRepresentable, Hashable, CustomStringConverti
     /**
      An alert that is relevant to a route leg.
      */
-    public static let alert = NotificationType(rawValue: "alert")
+    public static let alert = RouteNotificationType(rawValue: "alert")
 
     /**
      The route leg violates a restriction.
      */
-    public static let violation = NotificationType(rawValue: "violation")
+    public static let violation = RouteNotificationType(rawValue: "violation")
 }
 
 /**
@@ -37,7 +37,7 @@ public struct NotificationType: RawRepresentable, Hashable, CustomStringConverti
 
  Unknown values are preserved for forward compatibility via `rawValue`.
  */
-public struct NotificationSubtype: RawRepresentable, Hashable, CustomStringConvertible {
+public struct RouteNotificationSubtype: RawRepresentable, Hashable, CustomStringConvertible {
     public let rawValue: String
 
     public init(rawValue: String) {
@@ -52,58 +52,58 @@ public struct NotificationSubtype: RawRepresentable, Hashable, CustomStringConve
      `type=violation` — The height of the vehicle is greater than the allowed height of the road.
      Provided when `max_height` is specified.
      */
-    public static let maxHeight = NotificationSubtype(rawValue: "maxHeight")
+    public static let maxHeight = RouteNotificationSubtype(rawValue: "maxHeight")
 
     /**
      `type=violation` — The width of the vehicle is greater than the allowed width of the road.
      Provided when `max_width` is specified.
      */
-    public static let maxWidth = NotificationSubtype(rawValue: "maxWidth")
+    public static let maxWidth = RouteNotificationSubtype(rawValue: "maxWidth")
 
     /**
      `type=violation` — The weight of the vehicle is greater than the allowed weight of the road.
      Provided when `max_weight` is specified.
      */
-    public static let maxWeight = NotificationSubtype(rawValue: "maxWeight")
+    public static let maxWeight = RouteNotificationSubtype(rawValue: "maxWeight")
 
     /**
      `type=violation` — Unpaved road, while it was explicitly requested to exclude unpaved roads.
      Provided when `exclude=unpaved`.
      */
-    public static let unpaved = NotificationSubtype(rawValue: "unpaved")
+    public static let unpaved = RouteNotificationSubtype(rawValue: "unpaved")
 
     /**
      `type=violation` — Road with tunnel, while it was explicitly requested to exclude tunnels.
      `type=alert` — Indicates a tunnel is on the route.
      */
-    public static let tunnel = NotificationSubtype(rawValue: "tunnel")
+    public static let tunnel = RouteNotificationSubtype(rawValue: "tunnel")
 
     /**
      `type=violation` — Toll road, while it was explicitly requested to exclude toll roads.
      `type=alert` — Indicates a toll road is on the route.
      */
-    public static let toll = NotificationSubtype(rawValue: "toll")
+    public static let toll = RouteNotificationSubtype(rawValue: "toll")
 
     /**
      `type=violation` — Undesirable road excluded by point.
      Provided when `exclude=point(longitude latitude)`.
      */
-    public static let pointExclusion = NotificationSubtype(rawValue: "pointExclusion")
+    public static let pointExclusion = RouteNotificationSubtype(rawValue: "pointExclusion")
 
     /**
      `type=violation` / `type=alert` — Indicates a country border crossing.
      */
-    public static let countryBorderCrossing = NotificationSubtype(rawValue: "countryBorderCrossing")
+    public static let countryBorderCrossing = RouteNotificationSubtype(rawValue: "countryBorderCrossing")
 
     /**
      `type=violation` / `type=alert` — Indicates a state border crossing.
      */
-    public static let stateBorderCrossing = NotificationSubtype(rawValue: "stateBorderCrossing")
+    public static let stateBorderCrossing = RouteNotificationSubtype(rawValue: "stateBorderCrossing")
 
     /**
      `type=violation` — Indicates a ferry crossing. Provided when `exclude=ferry`.
      */
-    public static let ferry = NotificationSubtype(rawValue: "ferry")
+    public static let ferry = RouteNotificationSubtype(rawValue: "ferry")
 }
 
 /**
@@ -111,7 +111,7 @@ public struct NotificationSubtype: RawRepresentable, Hashable, CustomStringConve
 
  Unknown values are preserved for forward compatibility via `rawValue`.
  */
-public struct NotificationRefreshType: RawRepresentable, Hashable, CustomStringConvertible {
+public struct RouteNotificationRefreshType: RawRepresentable, Hashable, CustomStringConvertible {
     public let rawValue: String
 
     public init(rawValue: String) {
@@ -125,18 +125,18 @@ public struct NotificationRefreshType: RawRepresentable, Hashable, CustomStringC
     /**
      A notification received with the initial route request or a refresh, then kept constant.
      */
-    public static let `static` = NotificationRefreshType(rawValue: "static")
+    public static let `static` = RouteNotificationRefreshType(rawValue: "static")
 
     /**
      A notification that is updated and reset with each route refresh.
      */
-    public static let dynamic = NotificationRefreshType(rawValue: "dynamic")
+    public static let dynamic = RouteNotificationRefreshType(rawValue: "dynamic")
 }
 
 /**
  The reason why a notification was issued.
  */
-public struct NotificationReason: RawRepresentable, Hashable, CustomStringConvertible {
+public struct RouteNotificationReason: RawRepresentable, Hashable, CustomStringConvertible {
     public let rawValue: String
 
     public init(rawValue: String) {
@@ -147,8 +147,8 @@ public struct NotificationReason: RawRepresentable, Hashable, CustomStringConver
         return rawValue
     }
 
-    public static let outOfOrder = NotificationReason(rawValue: "outOfOrder")
-    public static let occupied = NotificationReason(rawValue: "occupied")
+    public static let outOfOrder = RouteNotificationReason(rawValue: "outOfOrder")
+    public static let occupied = RouteNotificationReason(rawValue: "occupied")
 }
 
 /**
@@ -156,7 +156,7 @@ public struct NotificationReason: RawRepresentable, Hashable, CustomStringConver
 
  See the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object).
  */
-public final class NotificationDetails: NSObject, NSSecureCoding {
+public final class RouteNotificationDetails: NSObject, NSSecureCoding {
 
     /**
      The optional requested value in the request.
@@ -197,8 +197,8 @@ public final class NotificationDetails: NSObject, NSSecureCoding {
      */
     public convenience init(json: [String: Any]) {
         self.init(
-            requestedValue: NotificationDetails.stringValue(from: json["requested_value"]),
-            actualValue: NotificationDetails.stringValue(from: json["actual_value"]),
+            requestedValue: RouteNotificationDetails.stringValue(from: json["requested_value"]),
+            actualValue: RouteNotificationDetails.stringValue(from: json["actual_value"]),
             unit: json["unit"] as? String,
             message: json["message"] as? String
         )
@@ -257,26 +257,26 @@ public final class NotificationDetails: NSObject, NSSecureCoding {
 
  According to the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object).
  */
-public final class Notification: NSObject, NSSecureCoding {
+public final class RouteNotification: NSObject, NSSecureCoding {
 
     /**
      The type of notification (`alert` or `violation`).
 
      Unknown API values are preserved in `rawValue`.
      */
-    public let type: NotificationType
+    public let type: RouteNotificationType
 
     /**
      The optional subtype of the notification.
 
-     Known values include `ferry`, `maxWidth`, `countryBorderCrossing`, and others defined by `NotificationSubtype`.
+     Known values include `ferry`, `maxWidth`, `countryBorderCrossing`, and others defined by `RouteNotificationSubtype`.
      */
-    public let subtype: NotificationSubtype?
+    public let subtype: RouteNotificationSubtype?
 
     /**
      The refresh type distinguishing static and dynamic notifications.
      */
-    public let refreshType: NotificationRefreshType
+    public let refreshType: RouteNotificationRefreshType
 
     /**
      The optional position in the coordinate list where the notification occurred, relative to the start of the leg.
@@ -296,18 +296,18 @@ public final class Notification: NSObject, NSSecureCoding {
     /**
      The optional details specific to the notification type and subtype.
      */
-    public let details: NotificationDetails?
+    public let details: RouteNotificationDetails?
 
     /**
      Initializes a notification with the given values.
      */
-    public init(type: NotificationType,
-                subtype: NotificationSubtype? = nil,
-                refreshType: NotificationRefreshType,
+    public init(type: RouteNotificationType,
+                subtype: RouteNotificationSubtype? = nil,
+                refreshType: RouteNotificationRefreshType,
                 geometryIndex: Int? = nil,
                 geometryIndexStart: Int? = nil,
                 geometryIndexEnd: Int? = nil,
-                details: NotificationDetails? = nil) {
+                details: RouteNotificationDetails? = nil) {
         self.type = type
         self.subtype = subtype
         self.refreshType = refreshType
@@ -328,24 +328,24 @@ public final class Notification: NSObject, NSSecureCoding {
             return nil
         }
 
-        let subtype: NotificationSubtype?
+        let subtype: RouteNotificationSubtype?
         if let subtypeString = json["subtype"] as? String {
-            subtype = NotificationSubtype(rawValue: subtypeString)
+            subtype = RouteNotificationSubtype(rawValue: subtypeString)
         } else {
             subtype = nil
         }
 
-        let details: NotificationDetails?
+        let details: RouteNotificationDetails?
         if let detailsJSON = json["details"] as? [String: Any] {
-            details = NotificationDetails(json: detailsJSON)
+            details = RouteNotificationDetails(json: detailsJSON)
         } else {
             details = nil
         }
 
         self.init(
-            type: NotificationType(rawValue: typeString),
+            type: RouteNotificationType(rawValue: typeString),
             subtype: subtype,
-            refreshType: NotificationRefreshType(rawValue: refreshTypeString),
+            refreshType: RouteNotificationRefreshType(rawValue: refreshTypeString),
             geometryIndex: json["geometry_index"] as? Int,
             geometryIndexStart: json["geometry_index_start"] as? Int,
             geometryIndexEnd: json["geometry_index_end"] as? Int,
@@ -359,13 +359,13 @@ public final class Notification: NSObject, NSSecureCoding {
             return nil
         }
 
-        type = NotificationType(rawValue: typeRawValue)
+        type = RouteNotificationType(rawValue: typeRawValue)
         if let subtypeRawValue = decoder.decodeObject(of: NSString.self, forKey: "subtype") as String? {
-            subtype = NotificationSubtype(rawValue: subtypeRawValue)
+            subtype = RouteNotificationSubtype(rawValue: subtypeRawValue)
         } else {
             subtype = nil
         }
-        refreshType = NotificationRefreshType(rawValue: refreshTypeRawValue)
+        refreshType = RouteNotificationRefreshType(rawValue: refreshTypeRawValue)
 
         if decoder.containsValue(forKey: "geometryIndex") {
             geometryIndex = decoder.decodeInteger(forKey: "geometryIndex")
@@ -383,7 +383,7 @@ public final class Notification: NSObject, NSSecureCoding {
             geometryIndexEnd = nil
         }
 
-        details = decoder.decodeObject(of: NotificationDetails.self, forKey: "details")
+        details = decoder.decodeObject(of: RouteNotificationDetails.self, forKey: "details")
     }
 
     public static var supportsSecureCoding = true

--- a/MapboxDirectionsTests/NotificationTests.swift
+++ b/MapboxDirectionsTests/NotificationTests.swift
@@ -106,25 +106,25 @@ class NotificationTests: XCTestCase {
     }
 
     func testNotificationPreservesUnknownValuesForForwardCompatibility() {
-        let notification = Notification(json: [
+        let notification = RouteNotification(json: [
             "type": "newType",
             "subtype": "newSubtype",
             "refresh_type": "newRefreshType"
         ])
 
         XCTAssertNotNil(notification)
-        XCTAssertEqual(notification?.type, NotificationType(rawValue: "newType"))
-        XCTAssertEqual(notification?.subtype, NotificationSubtype(rawValue: "newSubtype"))
-        XCTAssertEqual(notification?.refreshType, NotificationRefreshType(rawValue: "newRefreshType"))
+        XCTAssertEqual(notification?.type, RouteNotificationType(rawValue: "newType"))
+        XCTAssertEqual(notification?.subtype, RouteNotificationSubtype(rawValue: "newSubtype"))
+        XCTAssertEqual(notification?.refreshType, RouteNotificationRefreshType(rawValue: "newRefreshType"))
     }
 
     func testNotificationRequiresTypeAndRefreshType() {
-        XCTAssertNil(Notification(json: ["refresh_type": "static"]))
-        XCTAssertNil(Notification(json: ["type": "alert"]))
+        XCTAssertNil(RouteNotification(json: ["refresh_type": "static"]))
+        XCTAssertNil(RouteNotification(json: ["type": "alert"]))
     }
 
     func testNotificationAllowsMessageOnlyDetailsAndNoSubtype() {
-        let notification = Notification(json: [
+        let notification = RouteNotification(json: [
             "type": "alert",
             "refresh_type": "dynamic",
             "details": [
@@ -166,14 +166,14 @@ class NotificationTests: XCTestCase {
     }
 
     func testNotificationJSONUsesDirectionsWireNames() {
-        let notification = Notification(
+        let notification = RouteNotification(
             type: .violation,
             subtype: nil,
             refreshType: .dynamic,
             geometryIndex: 5,
             geometryIndexStart: 4,
             geometryIndexEnd: 6,
-            details: NotificationDetails(
+            details: RouteNotificationDetails(
                 requestedValue: "3",
                 actualValue: "2.5"
             )
@@ -196,17 +196,17 @@ class NotificationTests: XCTestCase {
     }
 
     func testNotificationSecureCodingRoundTrip() {
-        let original = Notification(
+        let original = RouteNotification(
             type: .alert,
             subtype: .ferry,
             refreshType: .static,
             geometryIndexStart: 10,
             geometryIndexEnd: 15,
-            details: NotificationDetails(message: "Ferry ahead")
+            details: RouteNotificationDetails(message: "Ferry ahead")
         )
 
         let data = try! NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
-        let decoded = try! NSKeyedUnarchiver.unarchivedObject(ofClass: Notification.self, from: data)
+        let decoded = try! NSKeyedUnarchiver.unarchivedObject(ofClass: RouteNotification.self, from: data)
 
         XCTAssertNotNil(decoded)
         XCTAssertEqual(decoded?.type, .alert)
@@ -218,7 +218,7 @@ class NotificationTests: XCTestCase {
     }
 
     func testNotificationDetailsCoercesNumericValuesToString() {
-        let details = NotificationDetails(json: [
+        let details = RouteNotificationDetails(json: [
             "requested_value": 3,
             "actual_value": 2.5,
             "unit": "m",

--- a/MapboxDirectionsTests/NotificationTests.swift
+++ b/MapboxDirectionsTests/NotificationTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable import MapboxDirections
+
+class NotificationTests: XCTestCase {
+    func testRouteLegDeserializesNotifications() {
+        let json: [String: Any] = [
+            "distance": 100.0,
+            "duration": 10.0,
+            "summary": "",
+            "steps": [],
+            "notifications": [
+                [
+                    "type": "violation",
+                    "subtype": "maxWidth",
+                    "refresh_type": "static",
+                    "geometry_index": 5,
+                    "geometry_index_start": 4,
+                    "geometry_index_end": 6,
+                    "details": [
+                        "requested_value": "3",
+                        "actual_value": "2.5",
+                        "unit": "m",
+                        "message": "Width restriction"
+                    ]
+                ]
+            ]
+        ]
+
+        let options = RouteOptions(coordinates: [
+            .init(latitude: 0, longitude: 0),
+            .init(latitude: 1, longitude: 1)
+        ])
+        let leg = RouteLeg(
+            json: json,
+            source: options.waypoints[0],
+            destination: options.waypoints[1],
+            options: options
+        )
+
+        XCTAssertEqual(leg.notifications.count, 1)
+        let notification = leg.notifications[0]
+        XCTAssertEqual(notification.type, .violation)
+        XCTAssertEqual(notification.subtype, .maxWidth)
+        XCTAssertEqual(notification.refreshType, .static)
+        XCTAssertEqual(notification.geometryIndex, 5)
+        XCTAssertEqual(notification.geometryIndexStart, 4)
+        XCTAssertEqual(notification.geometryIndexEnd, 6)
+        XCTAssertEqual(notification.details?.requestedValue, "3")
+        XCTAssertEqual(notification.details?.actualValue, "2.5")
+        XCTAssertEqual(notification.details?.unit, "m")
+        XCTAssertEqual(notification.details?.message, "Width restriction")
+    }
+
+    func testRouteLegDeserializesPointAndRangeNotifications() {
+        let json: [String: Any] = [
+            "distance": 100.0,
+            "duration": 10.0,
+            "summary": "",
+            "steps": [],
+            "notifications": [
+                [
+                    "type": "alert",
+                    "subtype": "countryBorderCrossing",
+                    "refresh_type": "dynamic",
+                    "geometry_index": 7
+                ],
+                [
+                    "type": "violation",
+                    "subtype": "ferry",
+                    "refresh_type": "static",
+                    "geometry_index_start": 10,
+                    "geometry_index_end": 15
+                ]
+            ]
+        ]
+
+        let options = RouteOptions(coordinates: [
+            .init(latitude: 0, longitude: 0),
+            .init(latitude: 1, longitude: 1)
+        ])
+        let leg = RouteLeg(
+            json: json,
+            source: options.waypoints[0],
+            destination: options.waypoints[1],
+            options: options
+        )
+
+        XCTAssertEqual(leg.notifications.count, 2)
+
+        let pointNotification = leg.notifications[0]
+        XCTAssertEqual(pointNotification.type, .alert)
+        XCTAssertEqual(pointNotification.subtype, .countryBorderCrossing)
+        XCTAssertEqual(pointNotification.refreshType, .dynamic)
+        XCTAssertEqual(pointNotification.geometryIndex, 7)
+        XCTAssertNil(pointNotification.geometryIndexStart)
+        XCTAssertNil(pointNotification.geometryIndexEnd)
+        XCTAssertNil(pointNotification.details)
+
+        let rangeNotification = leg.notifications[1]
+        XCTAssertEqual(rangeNotification.type, .violation)
+        XCTAssertEqual(rangeNotification.subtype, .ferry)
+        XCTAssertEqual(rangeNotification.refreshType, .static)
+        XCTAssertNil(rangeNotification.geometryIndex)
+        XCTAssertEqual(rangeNotification.geometryIndexStart, 10)
+        XCTAssertEqual(rangeNotification.geometryIndexEnd, 15)
+    }
+
+    func testNotificationPreservesUnknownValuesForForwardCompatibility() {
+        let notification = Notification(json: [
+            "type": "newType",
+            "subtype": "newSubtype",
+            "refresh_type": "newRefreshType"
+        ])
+
+        XCTAssertNotNil(notification)
+        XCTAssertEqual(notification?.type, .unknown)
+        XCTAssertEqual(notification?.typeDescription, "newType")
+        XCTAssertEqual(notification?.subtype, NotificationSubtype(rawValue: "newSubtype"))
+        XCTAssertEqual(notification?.refreshType, NotificationRefreshType(rawValue: "newRefreshType"))
+    }
+
+    func testNotificationRequiresTypeAndRefreshType() {
+        XCTAssertNil(Notification(json: ["refresh_type": "static"]))
+        XCTAssertNil(Notification(json: ["type": "alert"]))
+    }
+
+    func testNotificationAllowsMessageOnlyDetailsAndNoSubtype() {
+        let notification = Notification(json: [
+            "type": "alert",
+            "refresh_type": "dynamic",
+            "details": [
+                "message": "Ferry service unavailable"
+            ]
+        ])
+
+        XCTAssertNotNil(notification)
+        XCTAssertNil(notification?.subtype)
+        XCTAssertNil(notification?.geometryIndex)
+        XCTAssertNil(notification?.geometryIndexStart)
+        XCTAssertNil(notification?.geometryIndexEnd)
+        XCTAssertNil(notification?.details?.requestedValue)
+        XCTAssertNil(notification?.details?.actualValue)
+        XCTAssertNil(notification?.details?.unit)
+        XCTAssertEqual(notification?.details?.message, "Ferry service unavailable")
+    }
+
+    func testRouteLegWithoutNotificationsReturnsEmptyList() {
+        let json: [String: Any] = [
+            "distance": 100.0,
+            "duration": 10.0,
+            "summary": "",
+            "steps": []
+        ]
+
+        let options = RouteOptions(coordinates: [
+            .init(latitude: 0, longitude: 0),
+            .init(latitude: 1, longitude: 1)
+        ])
+        let leg = RouteLeg(
+            json: json,
+            source: options.waypoints[0],
+            destination: options.waypoints[1],
+            options: options
+        )
+
+        XCTAssertEqual(leg.notifications.count, 0)
+    }
+
+    func testNotificationJSONUsesDirectionsWireNames() {
+        let notification = Notification(
+            type: .violation,
+            subtype: nil,
+            refreshType: .dynamic,
+            geometryIndex: 5,
+            geometryIndexStart: 4,
+            geometryIndexEnd: 6,
+            details: NotificationDetails(
+                requestedValue: "3",
+                actualValue: "2.5"
+            )
+        )
+
+        let json = notification.json
+        XCTAssertEqual(json["type"] as? String, "violation")
+        XCTAssertEqual(json["refresh_type"] as? String, "dynamic")
+        XCTAssertEqual(json["geometry_index"] as? Int, 5)
+        XCTAssertEqual(json["geometry_index_start"] as? Int, 4)
+        XCTAssertEqual(json["geometry_index_end"] as? Int, 6)
+        XCTAssertNil(json["subtype"])
+
+        let details = json["details"] as? [String: Any]
+        XCTAssertEqual(details?["requested_value"] as? String, "3")
+        XCTAssertEqual(details?["actual_value"] as? String, "2.5")
+        XCTAssertNil(details?["unit"])
+        XCTAssertNil(details?["message"])
+        XCTAssertNil(notification.subtype)
+    }
+
+    func testNotificationSecureCodingRoundTrip() {
+        let original = Notification(
+            type: .alert,
+            subtype: .ferry,
+            refreshType: .static,
+            geometryIndexStart: 10,
+            geometryIndexEnd: 15,
+            details: NotificationDetails(message: "Ferry ahead")
+        )
+
+        let data = try! NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
+        let decoded = try! NSKeyedUnarchiver.unarchivedObject(ofClass: Notification.self, from: data)
+
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.type, .alert)
+        XCTAssertEqual(decoded?.subtype, .ferry)
+        XCTAssertEqual(decoded?.refreshType, .static)
+        XCTAssertEqual(decoded?.geometryIndexStart, 10)
+        XCTAssertEqual(decoded?.geometryIndexEnd, 15)
+        XCTAssertEqual(decoded?.details?.message, "Ferry ahead")
+    }
+
+    func testNotificationDetailsCoercesNumericValuesToString() {
+        let details = NotificationDetails(json: [
+            "requested_value": 3,
+            "actual_value": 2.5,
+            "unit": "m",
+            "message": "Width restriction"
+        ])
+
+        XCTAssertEqual(details.requestedValue, "3")
+        XCTAssertEqual(details.actualValue, "2.5")
+        XCTAssertEqual(details.unit, "m")
+        XCTAssertEqual(details.message, "Width restriction")
+    }
+}

--- a/MapboxDirectionsTests/NotificationTests.swift
+++ b/MapboxDirectionsTests/NotificationTests.swift
@@ -113,8 +113,7 @@ class NotificationTests: XCTestCase {
         ])
 
         XCTAssertNotNil(notification)
-        XCTAssertEqual(notification?.type, .unknown)
-        XCTAssertEqual(notification?.typeDescription, "newType")
+        XCTAssertEqual(notification?.type, NotificationType(rawValue: "newType"))
         XCTAssertEqual(notification?.subtype, NotificationSubtype(rawValue: "newSubtype"))
         XCTAssertEqual(notification?.refreshType, NotificationRefreshType(rawValue: "newRefreshType"))
     }


### PR DESCRIPTION
### Description of PR
In this PR we are adding notifications to route legs. These offer us the possibility to warn drivers of potential risks on their route. These notifications are implemented in accordance with the Mapbox spec outlined [here](https://docs.mapbox.com/api/navigation/directions/#notification-object).

This is the iOS counterpart of [maplibre/maplibre-navigation-android#230](https://github.com/maplibre/maplibre-navigation-android/pull/230).

### Why
At Flitsmeister we are looking to implement ferry notifications in our routing module. At the moment the `RouteLeg` object does not know how to parse said ferry notifications, so we could either parse the raw JSON ourselves and hack some way around it, or we could add it to the `RouteLeg` object as an expansion.

### Changes
- Added `Notification`, `NotificationDetails`, and related type/subtype/refresh models
- Added `RouteLeg.notifications` (defaults to an empty array when absent)
- Preserved unknown type/subtype/refresh values for forward compatibility
- Added unit tests covering parsing, serialization, validation, defaults, and secure coding

### Test plan
- [x] `swift test --filter NotificationTests`
- [ ] Review public API surface for ObjC/Swift consumers
- [ ] Verify a Directions response containing ferry (and other) notifications populates `RouteLeg.notifications`


Made with [Cursor](https://cursor.com)