### PR TITLE
Make RouteNotification refresh_type optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Directions SDK for iOS
 
+## v0.23.5
+
+* Made `refresh_type` optional when parsing `RouteNotification` JSON; defaults to `.static` when omitted. Geometry index fields also accept `NSNumber` values from JSON deserialization. ([#9](https://github.com/flitsmeister/mapbox-directions-swift/pull/9))
+
 ## v0.23.4
 
 * Added support for route leg notifications (`RouteNotification`), including alerts, violations, refresh behavior, subtypes, and notification details, following the [Mapbox Directions API notification object](https://docs.mapbox.com/api/navigation/directions/#notification-object). ([#8](https://github.com/flitsmeister/mapbox-directions-swift/pull/8))

--- a/MapboxDirections/MBRouteNotification.swift
+++ b/MapboxDirections/MBRouteNotification.swift
@@ -320,11 +320,11 @@ public final class RouteNotification: NSObject, NSSecureCoding {
     /**
      Initializes a notification from a JSON dictionary representation.
 
-     Returns `nil` if required fields `type` or `refresh_type` are missing.
+     Returns `nil` if the required field `type` is missing.
+     When `refresh_type` is absent, defaults to `.static` (some providers omit it).
      */
     public convenience init?(json: [String: Any]) {
-        guard let typeString = json["type"] as? String,
-              let refreshTypeString = json["refresh_type"] as? String else {
+        guard let typeString = json["type"] as? String else {
             return nil
         }
 
@@ -342,13 +342,20 @@ public final class RouteNotification: NSObject, NSSecureCoding {
             details = nil
         }
 
+        let refreshType: RouteNotificationRefreshType
+        if let refreshTypeString = json["refresh_type"] as? String {
+            refreshType = RouteNotificationRefreshType(rawValue: refreshTypeString)
+        } else {
+            refreshType = .static
+        }
+
         self.init(
             type: RouteNotificationType(rawValue: typeString),
             subtype: subtype,
-            refreshType: RouteNotificationRefreshType(rawValue: refreshTypeString),
-            geometryIndex: json["geometry_index"] as? Int,
-            geometryIndexStart: json["geometry_index_start"] as? Int,
-            geometryIndexEnd: json["geometry_index_end"] as? Int,
+            refreshType: refreshType,
+            geometryIndex: (json["geometry_index"] as? NSNumber)?.intValue,
+            geometryIndexStart: (json["geometry_index_start"] as? NSNumber)?.intValue,
+            geometryIndexEnd: (json["geometry_index_end"] as? NSNumber)?.intValue,
             details: details
         )
     }

--- a/MapboxDirectionsTests/NotificationTests.swift
+++ b/MapboxDirectionsTests/NotificationTests.swift
@@ -118,9 +118,24 @@ class NotificationTests: XCTestCase {
         XCTAssertEqual(notification?.refreshType, RouteNotificationRefreshType(rawValue: "newRefreshType"))
     }
 
-    func testNotificationRequiresTypeAndRefreshType() {
+    func testNotificationRequiresType() {
         XCTAssertNil(RouteNotification(json: ["refresh_type": "static"]))
-        XCTAssertNil(RouteNotification(json: ["type": "alert"]))
+    }
+
+    func testNotificationDefaultsRefreshTypeWhenMissing() {
+        let notification = RouteNotification(json: [
+            "type": "alert",
+            "subtype": "ferry",
+            "geometry_index_start": 335,
+            "geometry_index_end": 339
+        ])
+
+        XCTAssertNotNil(notification)
+        XCTAssertEqual(notification?.type, .alert)
+        XCTAssertEqual(notification?.subtype, .ferry)
+        XCTAssertEqual(notification?.refreshType, .static)
+        XCTAssertEqual(notification?.geometryIndexStart, 335)
+        XCTAssertEqual(notification?.geometryIndexEnd, 339)
     }
 
     func testNotificationAllowsMessageOnlyDetailsAndNoSubtype() {


### PR DESCRIPTION
## Summary
- Treat missing `refresh_type` as `.static` when parsing `RouteNotification` JSON (BeMobile ferry notifications omit it)
- Accept `NSNumber` for geometry index fields from JSON deserialization
- Add regression test for ferry notification without `refresh_type`

## Test plan
- [ ] `NotificationTests.testNotificationDefaultsRefreshTypeWhenMissing` passes
- [ ] Ferry route via BeMobile Acceptance shows notifications again in FM

Made with [Cursor](https://cursor.com)